### PR TITLE
fix(typo): Check if variable exists before using it + typo

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -44,9 +44,7 @@ then
       notify-send -u low 'System' 'Checking source packages...'
     fi
 
-    echo -n '' > $upd_logFile
-
-    if [ -f $upd_exludeFile ]
+    if [[ -z $upd_excludeFile && -f $upd_excludeFile ]]
     then
       for i in $(cat $upd_excludeFile)
       do


### PR DESCRIPTION
hello,

this change fix a typo for when there is no exclude list and add a check before using the variable to avoid an infinite wait if it is not define.

Charles