### PR TITLE
Tag support: master, aur, branch, tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,55 +1,78 @@
-# `zscripts`
+# zscripts
 
-`zscripts` is a set of `zsh` scripts designed for Arch Linux users.
+*zscripts* is a set of `zsh` scripts designed for Arch Linux users.
 
 Depending on the script you want to use, you must install some dependencies too:
-- update
-```
-cronie
-dunst
-libnotify
-```
+- *update.sh*:
+    * cronie    [optional]
+    * dunst     [optional]
+    * libnotify [optinal]
 
-- screen
-```
-screen
-htop
-nload
-nvidia-smi
-```
+- *screen.sh*:
+    * screen
+    * htop
+    * nload
+    * nvidia-smi
 
-- lock
-```
-i3lock
-imagemagick
-scrot
-```
+- *lock.sh*:
+    * i3lock
+    * imagemagick
+    * scrot
 
-Scripts
--------
+# Content
+---------
+
 Several scripts are also provided to make your life happier:
 
-- **update**
+## Update
 
-This script typically visits source directories to check for updates. It currently support `git` and `zsh`
-and is able to check in particular Arch User Repositories (AUR) or other git versioned repositories and
-system updates.
+This script manage packages update.
+It will check for system updates and also for sources included in the file
+`$UPD_SOURCE_FILE`. By default, this file is `$HOME/.config/autoUpdateList`.
+This file should contain a list of directory to watch for updates, one per
+line. You can also add tags using `#` to manage how update will be managed.
+there is actually four tag supported:
+* `#master` *optional*: this is the default behaviour, update this git repository to any new commit only if the current branch is *master*.
+* `#aur` *optional*: for aur repository, the script will automatically detect them even without the tag.
+* `#branch`: update the current branch of this git repository, even if not on master
+* `#tag`: update the current git repository only to new tagged version
 
-You can add this script to a cron table and if the correct dependencies are installed, notifications
-will be sent.
+Here is an example of such file:
 
-For example, to check for updates every hour:
+
+```
+$HOME/.config/zscript
+$HOME/.config/zsh#master
+$HOME/Software/aur/package1
+$HOME/Software/aur/package2#aur
+$HOME/Software/work/my_project#branch
+$HOME/Software/lib/lib_release#tag
+```
+
+Here, scripts in `.config` asould be on *master* and so can be updated
+automatically (same with and without the tag). The AUR packages are also
+watched for update (with and without the tag).
+Then, *my_project/* can be updated no matter which branch is the current one and
+the *lib_release/* will be updated only on new tagged version.
+
+### Use
+
+This script work in two steps, first it check for update without touching any folder.
+This allows the check for update to run in the background, like in a cron tab.
+Here is an example of a cron to check for updates every hour:
 
 `0 * * * * $HOME/zscripts/update.sh --scan`
 
 Notice the `--scan` argument which is sent to specify that you want to check for update.
 
-Optionally, an automatic installation procedure is applied as soon as updates are detected
-if you source this script from your `.zshrc` file like the following:
+Then, to process to the update, you need to source the `update.sh` file.
 
 `source $HOME/zscripts/update.sh`
 
-- **screen**
+If you add this line in your `.zshrc`, your shell will propose to update (if
+needed) whenever you open it.
+
+## Screen
 
 This script is designed to be sourced in the `.zshrc` configuration file like the following:
 
@@ -57,13 +80,13 @@ This script is designed to be sourced in the `.zshrc` configuration file like th
 
 It is able to detect and load pre-configured GNU `screen` sessions.
 
-- **lock**
+## Lock
 
 This script lock the screen and use a blurred screenshot image as lockscreen image. An optional image
 (e.g. a logo) can be added at the center.
 
-User variables
---------------
+# User configuration
+--------------------
 
 Each script can be customized through different variables, take a look at the beginning of each script
 after the section *Configuration variables*. Feel free to modify these variables to suit your needs


### PR DESCRIPTION
Dear guillaume,

As explained in the README, the *update.sh* script is now able to manage update more cleverly using tag.
These are writtend by using `#tag` after the path in the `$UPD_SOURCE_FILE`:
* The `#master` correspond to the default behavior and so is optional.
* The `#aur` for aur repository is also optional as the script can detect such cases.
* The `#branch` tag makes the script update the current branch even if it is not *master*
* The `#tag` tag tag make the script update only to tagged version on the git repository.

Cheers
